### PR TITLE
Dictionary snippets: say a phrase, write the whole thing

### DIFF
--- a/App/Sources/Windows/DictionaryView.swift
+++ b/App/Sources/Windows/DictionaryView.swift
@@ -18,13 +18,16 @@ import JotCore
 
 /// The dictionary manager: teach it your words once, they're spelled right forever.
 /// Terms ride in the cleanup prompt; explicit misspelling rules are enforced
-/// deterministically after every dictation.
+/// deterministically after every dictation. An entry can also carry an EXPANSION,
+/// which turns its term into a spoken shortcut — say "my email address", get the
+/// address. Expansions are substituted locally and never sent to the API.
 struct DictionaryView: View {
     private let store = DictionaryStore()
 
     @State private var entries: [DictionaryEntry] = []
     @State private var newTerm = ""
     @State private var newMisspelling = ""
+    @State private var newExpansion = ""
     @State private var search = ""
     /// Transient feedback under the add row / in the footer ("Already in your
     /// dictionary", "Imported 12 words") — silence on a failed action reads as
@@ -47,22 +50,31 @@ struct DictionaryView: View {
     }
 
     private var addRow: some View {
-        HStack(spacing: JotUI.Spacing.xs) {
-            TextField("Add a word or phrase…", text: $newTerm)
-                .textFieldStyle(.plain)
-                .font(JotUI.TypeScale.body(grad: grad))
-                .onSubmit(add)
-            TextField("Gemini hears it as… (optional)", text: $newMisspelling)
-                .textFieldStyle(.plain)
-                .font(JotUI.TypeScale.body(grad: grad))
-                .foregroundStyle(JotUI.Colors.onSurfaceVariant)
-                .onSubmit(add)
-            Button(action: add) {
-                Image(systemName: "plus.circle.fill")
-                    .foregroundStyle(newTerm.isEmpty ? JotUI.Colors.onSurfaceVariant : JotUI.Colors.primary)
+        VStack(spacing: JotUI.Spacing.xs) {
+            HStack(spacing: JotUI.Spacing.xs) {
+                TextField("Add a word or phrase…", text: $newTerm)
+                    .textFieldStyle(.plain)
+                    .font(JotUI.TypeScale.body(grad: grad))
+                    .onSubmit(add)
+                Button(action: add) {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(newTerm.isEmpty ? JotUI.Colors.onSurfaceVariant : JotUI.Colors.primary)
+                }
+                .buttonStyle(.plain)
+                .disabled(newTerm.isEmpty)
             }
-            .buttonStyle(.plain)
-            .disabled(newTerm.isEmpty)
+            HStack(spacing: JotUI.Spacing.xs) {
+                TextField("Gemini hears it as… (optional)", text: $newMisspelling)
+                    .textFieldStyle(.plain)
+                    .font(JotUI.TypeScale.body(grad: grad))
+                    .foregroundStyle(JotUI.Colors.onSurfaceVariant)
+                    .onSubmit(add)
+                TextField("Expands to… (optional)", text: $newExpansion)
+                    .textFieldStyle(.plain)
+                    .font(JotUI.TypeScale.body(grad: grad))
+                    .foregroundStyle(JotUI.Colors.onSurfaceVariant)
+                    .onSubmit(add)
+            }
         }
         .padding(JotUI.Spacing.s)
         .background(RoundedRectangle(cornerRadius: JotUI.Radius.medium).fill(JotUI.Colors.surfaceContainer))
@@ -77,6 +89,7 @@ struct DictionaryView: View {
         let matching = search.isEmpty ? base : base.filter {
             $0.term.localizedCaseInsensitiveContains(search)
                 || ($0.misspelling?.localizedCaseInsensitiveContains(search) ?? false)
+                || ($0.expansion?.localizedCaseInsensitiveContains(search) ?? false)
         }
         return matching.map { FilteredEntry(entry: $0) }
     }
@@ -109,6 +122,15 @@ struct DictionaryView: View {
                             .font(JotUI.TypeScale.labelSmall(grad: grad))
                             .foregroundStyle(JotUI.Colors.onSurfaceVariant)
                     }
+                    if let expansion = entry.expansion, !expansion.isEmpty {
+                        // Flattened, not just line-limited: a multi-line signature
+                        // would otherwise preview as its first line alone.
+                        Text("say it → \(expansion.replacingOccurrences(of: "\n", with: " "))")
+                            .font(JotUI.TypeScale.labelSmall(grad: grad))
+                            .foregroundStyle(JotUI.Colors.primary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
                 }
                 Spacer()
                 Button {
@@ -137,7 +159,7 @@ struct DictionaryView: View {
             Text("Teach it your words")
                 .font(JotUI.TypeScale.title(grad: grad))
                 .foregroundStyle(JotUI.Colors.onSurface)
-            Text("Names, jargon, product terms — add them once,\nthey're spelled right in every dictation.")
+            Text("Names, jargon, product terms — add them once,\nthey're spelled right in every dictation.\nGive one an expansion and saying it writes the whole thing.")
                 .font(JotUI.TypeScale.body(grad: grad))
                 .foregroundStyle(JotUI.Colors.onSurfaceVariant)
                 .multilineTextAlignment(.center)
@@ -165,13 +187,25 @@ struct DictionaryView: View {
     // MARK: - Actions
 
     private func add() {
-        guard store.add(term: newTerm, misspelling: newMisspelling.isEmpty ? nil : newMisspelling) else {
+        let expansion = newExpansion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard store.add(
+            term: newTerm,
+            misspelling: newMisspelling.isEmpty ? nil : newMisspelling,
+            expansion: expansion.isEmpty ? nil : expansion
+        ) else {
             let trimmed = newTerm.trimmingCharacters(in: .whitespacesAndNewlines)
-            showFeedback(trimmed.count > 60 ? "Keep terms under 60 characters" : "Already in your dictionary")
+            if trimmed.count > 60 {
+                showFeedback("Keep terms under 60 characters")
+            } else if expansion.count > DictionaryEntry.maxExpansionLength {
+                showFeedback("Keep expansions under \(DictionaryEntry.maxExpansionLength) characters")
+            } else {
+                showFeedback("Already in your dictionary")
+            }
             return
         }
         newTerm = ""
         newMisspelling = ""
+        newExpansion = ""
         reload()
     }
 

--- a/JotCore/Sources/FormattingPipeline/ReplacementEngine.swift
+++ b/JotCore/Sources/FormattingPipeline/ReplacementEngine.swift
@@ -29,6 +29,66 @@ public enum ReplacementEngine {
         }
     }
 
+    /// A spoken trigger that expands to arbitrary text ("my email address" → the
+    /// address). A spelling rule corrects a word the model misheard; a snippet
+    /// substitutes something the user never said in full. Hence the two rules in
+    /// `expand`: verbatim insertion, and no re-scanning.
+    public struct Snippet: Codable, Equatable, Sendable {
+        public var trigger: String
+        public var expansion: String
+
+        public init(trigger: String, expansion: String) {
+            self.trigger = trigger
+            self.expansion = expansion
+        }
+    }
+
+    /// Expands snippet triggers in one pass over the ORIGINAL text.
+    ///
+    /// Single-pass is the point, not an optimisation. `apply` rewrites `result`
+    /// once per rule, which is harmless for short spelling corrections but not
+    /// for snippets: an expansion is arbitrary user text, so a later rule could
+    /// match INSIDE freshly-inserted content and corrupt it — expand "my email"
+    /// to an address, then watch a "gmail" rule chew the domain. Matching the
+    /// original and copying the gaps makes that structurally impossible.
+    ///
+    /// Expansions are inserted verbatim: `apply`'s case propagation would
+    /// Title-Case an address whenever its trigger opened a sentence.
+    public static func expand(_ snippets: [Snippet], in text: String) -> String {
+        // Longest trigger first, so "my work email" beats "my email". Leftmost
+        // match is NSRegularExpression's; longest-at-a-position is ours, via
+        // alternation order — it prefers the earliest listed alternative.
+        let ordered = snippets
+            .filter { !$0.trigger.isEmpty && !$0.expansion.isEmpty }
+            .sorted { $0.trigger.count > $1.trigger.count }
+        guard !ordered.isEmpty else { return text }
+
+        let expansions = Dictionary(
+            ordered.map { ($0.trigger.lowercased(), $0.expansion) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        // Same lookarounds as apply(): \b never matches when a trigger starts or
+        // ends in punctuation, and triggers are user-authored phrases.
+        let alternation = ordered
+            .map { NSRegularExpression.escapedPattern(for: $0.trigger) }
+            .joined(separator: "|")
+        guard let regex = try? NSRegularExpression(
+            pattern: "(?<![\\w])(?:\(alternation))(?![\\w])",
+            options: [.caseInsensitive]
+        ) else { return text }
+
+        var out = ""
+        var cursor = text.startIndex
+        for match in regex.matches(in: text, range: NSRange(text.startIndex..., in: text)) {
+            guard let range = Range(match.range, in: text) else { continue }
+            let matched = text[range]
+            out += text[cursor..<range.lowerBound]
+            out += expansions[matched.lowercased()] ?? String(matched)
+            cursor = range.upperBound
+        }
+        return out + text[cursor...]
+    }
+
     public static func apply(_ rules: [Rule], to text: String) -> String {
         guard !rules.isEmpty else { return text }
         var result = text

--- a/JotCore/Sources/Settings/DictionaryStore.swift
+++ b/JotCore/Sources/Settings/DictionaryStore.swift
@@ -14,22 +14,35 @@
 
 import Foundation
 
-/// The personal dictionary: terms (spelling hints fed to the cleanup prompt) and
-/// explicit wrong→right rules (enforced deterministically post-model).
+/// The personal dictionary: terms (spelling hints fed to the cleanup prompt),
+/// explicit wrong→right rules (enforced deterministically post-model), and
+/// snippets (a spoken trigger that expands to text you never said in full).
 /// UserDefaults-backed — entries are small and this keeps v1 dependency-free.
 public struct DictionaryEntry: Codable, Equatable, Identifiable, Sendable {
     public var id: UUID
-    /// The correct term ("Kubernetes", "Ammaar", "gRPC"). 1–60 chars.
+    /// The correct term ("Kubernetes", "Ammaar", "gRPC"), or — when `expansion`
+    /// is set — the spoken trigger ("my email address"). 1–60 chars.
     public var term: String
     /// Optional misspelling the model tends to produce ("cooper netties").
     public var misspelling: String?
+    /// Present ⇒ this entry is a snippet and `term` is the phrase the user
+    /// speaks. Optional so entries written by older builds still decode
+    /// (synthesised Codable uses decodeIfPresent for optionals).
+    public var expansion: String?
     public var starred: Bool
     public var createdAt: Date
 
-    public init(term: String, misspelling: String? = nil, starred: Bool = false) {
+    /// Long enough for a dictated instruction paragraph; bounded so a runaway
+    /// paste can't wedge the store or the editor.
+    public static let maxExpansionLength = 2_000
+
+    public var isSnippet: Bool { !(expansion ?? "").isEmpty }
+
+    public init(term: String, misspelling: String? = nil, expansion: String? = nil, starred: Bool = false) {
         self.id = UUID()
         self.term = term
         self.misspelling = misspelling
+        self.expansion = expansion
         self.starred = starred
         self.createdAt = Date()
     }
@@ -56,12 +69,20 @@ public struct DictionaryStore: Sendable {
     }
 
     @discardableResult
-    public func add(term: String, misspelling: String? = nil) -> Bool {
+    public func add(term: String, misspelling: String? = nil, expansion: String? = nil) -> Bool {
         let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
         guard (1...60).contains(trimmed.count) else { return false }
+        // Only the OUTER whitespace goes: an expansion is inserted verbatim, and
+        // a multi-line signature's interior newlines are the point.
+        let cleanedExpansion = expansion?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let cleanedExpansion, cleanedExpansion.count > DictionaryEntry.maxExpansionLength { return false }
         var current = entries()
         guard !current.contains(where: { $0.term.lowercased() == trimmed.lowercased() }) else { return false }
-        current.append(DictionaryEntry(term: trimmed, misspelling: misspelling?.trimmingCharacters(in: .whitespacesAndNewlines)))
+        current.append(DictionaryEntry(
+            term: trimmed,
+            misspelling: misspelling?.trimmingCharacters(in: .whitespacesAndNewlines),
+            expansion: (cleanedExpansion?.isEmpty ?? true) ? nil : cleanedExpansion
+        ))
         save(current)
         return true
     }
@@ -99,6 +120,10 @@ public struct DictionaryStore: Sendable {
     /// the per-term caps allow. Only CORRECT terms — never misspellings; biasing
     /// a recogniser toward "cooper netties" is actively harmful, and spellings()
     /// sits close enough to be wired up by accident.
+    ///
+    /// Snippet TRIGGERS ride along — the recogniser hearing "my email address"
+    /// cleanly is what makes expansion fire. EXPANSIONS never leave the machine;
+    /// they are substituted locally, after the response.
     public func sanitizedVocabulary(maxBytes: Int = 2_048) -> [String] {
         var used = 0
         var out: [String] = []
@@ -140,14 +165,27 @@ public struct DictionaryStore: Sendable {
         }
     }
 
+    /// Every entry carrying an expansion. Unordered on purpose — expand() sorts
+    /// by trigger length itself, and add() already rejects duplicate terms.
+    public func snippets() -> [ReplacementEngine.Snippet] {
+        entries().compactMap { entry in
+            guard let expansion = entry.expansion, !expansion.isEmpty else { return nil }
+            return ReplacementEngine.Snippet(trigger: entry.term, expansion: expansion)
+        }
+    }
+
     // MARK: - CSV (data portability)
 
+    /// Third column is the snippet expansion. It may legally contain commas,
+    /// quotes and NEWLINES — all three survive because every cell is quoted on
+    /// the way out and splitRecords() below is quote-aware on the way back in.
     public func exportCSV() -> String {
-        var lines = ["term,misspelling"]
+        var lines = ["term,misspelling,expansion"]
         for entry in entries() {
             let term = entry.term.replacingOccurrences(of: "\"", with: "\"\"")
             let misspelling = (entry.misspelling ?? "").replacingOccurrences(of: "\"", with: "\"\"")
-            lines.append("\"\(term)\",\"\(misspelling)\"")
+            let expansion = (entry.expansion ?? "").replacingOccurrences(of: "\"", with: "\"\"")
+            lines.append("\"\(term)\",\"\(misspelling)\",\"\(expansion)\"")
         }
         return lines.joined(separator: "\n")
     }
@@ -197,7 +235,15 @@ public struct DictionaryStore: Sendable {
             let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
             guard (1...60).contains(term.count), !seen.contains(term.lowercased()) else { continue }
             let misspelling = columns.count > 1 && !columns[1].isEmpty ? columns[1] : nil
-            current.append(DictionaryEntry(term: term, misspelling: misspelling))
+            // Drop an over-long expansion rather than the whole row: the term is
+            // still a useful hint, and a truncated address that LOOKS right is
+            // worse than none.
+            var expansion = columns.count > 2 && !columns[2].isEmpty ? columns[2] : nil
+            if let candidate = expansion, candidate.count > DictionaryEntry.maxExpansionLength {
+                Log.ui.warning("dictionary import: expansion exceeded the cap — imported the term without it")
+                expansion = nil
+            }
+            current.append(DictionaryEntry(term: term, misspelling: misspelling, expansion: expansion))
             seen.insert(term.lowercased())
             imported += 1
         }

--- a/JotCore/Sources/TranscriptionClient/GeminiTranscriptionService.swift
+++ b/JotCore/Sources/TranscriptionClient/GeminiTranscriptionService.swift
@@ -84,8 +84,7 @@ public struct GeminiTranscriptionService: TranscriptionServicing {
             // (audit L9). The gate is deliberately NOT run here: with no second
             // model there is no independent reference, and validate(raw:X, cleaned:X)
             // passes trivially, so running it would be theatre rather than safety.
-            let rules = DictionaryStore().replacementRules()
-            let text = ReplacementEngine.apply(rules, to: trimmedRaw)
+            let text = Self.applyDictionary(to: trimmedRaw)
             return TranscriptionResult(
                 rawTranscript: trimmedRaw,
                 cleanedTranscript: text,
@@ -192,6 +191,16 @@ public struct GeminiTranscriptionService: TranscriptionServicing {
         }
     }
 
+    /// The dictionary's post-model half, in one place because it has four call
+    /// sites and an ORDER that matters: spelling rules first, expansion second.
+    /// Reversed, a spelling rule rewrites the inside of a freshly-inserted
+    /// expansion — the user's own address, corrected into something they never
+    /// wrote.
+    static func applyDictionary(to text: String, _ dictionary: DictionaryStore = DictionaryStore()) -> String {
+        let corrected = ReplacementEngine.apply(dictionary.replacementRules(), to: text)
+        return ReplacementEngine.expand(dictionary.snippets(), in: corrected)
+    }
+
     private func cleanupOrFallback(raw: String, context: DictationContext, config: GeminiConfig) async -> String {
         let tone = PromptV1.toneCategory(forBundleID: context.targetAppBundleID)
         let dictionary = DictionaryStore()
@@ -212,15 +221,15 @@ public struct GeminiTranscriptionService: TranscriptionServicing {
                 let trips = settings.recordGateTrip()
                 Log.transcription.warning("cleanup gate REJECTED (\(verdict.reason ?? "?", privacy: .public), trip #\(trips) in 24h) — inserting raw")
                 autoDegradeIfNeeded(trips: trips)
-                return ReplacementEngine.apply(dictionary.replacementRules(), to: raw)
+                return Self.applyDictionary(to: raw, dictionary)
             }
             // The dictionary's hard guarantee: explicit wrong→right rules always win.
-            return ReplacementEngine.apply(dictionary.replacementRules(), to: cleaned)
+            return Self.applyDictionary(to: cleaned, dictionary)
         } catch {
             // Deadline miss / network hiccup on cleanup never costs the dictation —
             // and the dictionary guarantee still holds (audit L9).
             Log.transcription.info("cleanup unavailable (\(String(describing: error), privacy: .public)) — inserting raw")
-            return ReplacementEngine.apply(dictionary.replacementRules(), to: raw)
+            return Self.applyDictionary(to: raw, dictionary)
         }
     }
 

--- a/JotCore/Tests/JotCoreTests/SnippetExpansionTests.swift
+++ b/JotCore/Tests/JotCoreTests/SnippetExpansionTests.swift
@@ -1,0 +1,224 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import JotCore
+
+final class SnippetExpansionTests: XCTestCase {
+    private func snippet(_ trigger: String, _ expansion: String) -> ReplacementEngine.Snippet {
+        .init(trigger: trigger, expansion: expansion)
+    }
+
+    func testExpandsSpokenTrigger() {
+        let out = ReplacementEngine.expand(
+            [snippet("my email address", "dev@example.com")],
+            in: "Ping me at my email address when you land"
+        )
+        XCTAssertEqual(out, "Ping me at dev@example.com when you land")
+    }
+
+    /// The single most important difference from a spelling rule. `apply` does
+    /// case propagation on purpose — "Standup"→"Stand-up" should follow the
+    /// sentence. An expansion must NOT: a trigger at the start of a sentence
+    /// would Title-Case an address or upper-case a phone number's words.
+    func testExpansionIsVerbatimNeverCaseAdjusted() {
+        let out = ReplacementEngine.expand(
+            [snippet("my email address", "dev@example.com")],
+            in: "My email address is the best way to reach me."
+        )
+        XCTAssertEqual(out, "dev@example.com is the best way to reach me.",
+                       "sentence-start capitalisation must not leak into the expansion")
+    }
+
+    func testAllCapsTriggerStillExpandsVerbatim() {
+        let out = ReplacementEngine.expand([snippet("my number", "(720) 555-0134")], in: "MY NUMBER")
+        XCTAssertEqual(out, "(720) 555-0134")
+    }
+
+    func testLongestTriggerWins() {
+        let out = ReplacementEngine.expand(
+            [snippet("my email", "personal@example.com"), snippet("my work email", "work@example.com")],
+            in: "use my work email please"
+        )
+        XCTAssertEqual(out, "use work@example.com please")
+    }
+
+    /// Expansion is deliberately NOT re-entrant. Matching runs against the
+    /// original text and the gaps are copied, so a trigger that happens to appear
+    /// inside another snippet's expansion stays literal — no surprise cascade and
+    /// no way to build a recursive pair that never terminates.
+    func testExpansionIsNotRescanned() {
+        let out = ReplacementEngine.expand(
+            [snippet("my signature", "Sudarshan — my number"), snippet("my number", "(720) 555-0134")],
+            in: "my signature"
+        )
+        XCTAssertEqual(out, "Sudarshan — my number",
+                       "a trigger inside an expansion must stay literal")
+    }
+
+    func testWordBoundaryRespected() {
+        let out = ReplacementEngine.expand([snippet("sig", "SIGNATURE")], in: "the design is assigned")
+        XCTAssertEqual(out, "the design is assigned")
+    }
+
+    /// The model punctuates, so the trigger almost always arrives with a period
+    /// or comma attached. The lookarounds must let that through untouched.
+    func testTrailingPunctuationSurvives() {
+        let out = ReplacementEngine.expand([snippet("my number", "(720) 555-0134")], in: "Call my number, thanks.")
+        XCTAssertEqual(out, "Call (720) 555-0134, thanks.")
+    }
+
+    func testMultipleOccurrences() {
+        let out = ReplacementEngine.expand([snippet("my email", "dev@example.com")], in: "my email or my email")
+        XCTAssertEqual(out, "dev@example.com or dev@example.com")
+    }
+
+    func testMultilineExpansionKeepsItsShape() {
+        let out = ReplacementEngine.expand([snippet("my signoff", "Thanks,\nSudarshan")], in: "my signoff")
+        XCTAssertEqual(out, "Thanks,\nSudarshan")
+    }
+
+    func testNoSnippetsIsIdentity() {
+        XCTAssertEqual(ReplacementEngine.expand([], in: "unchanged"), "unchanged")
+    }
+
+    func testEmptyTriggerOrExpansionIsIgnored() {
+        let out = ReplacementEngine.expand(
+            [snippet("", "boom"), snippet("trigger", "")],
+            in: "trigger stays"
+        )
+        XCTAssertEqual(out, "trigger stays")
+    }
+}
+
+/// The ORDER guarantee between the dictionary's two post-model passes.
+final class DictionaryPipelineOrderTests: XCTestCase {
+    private let store = DictionaryStore()
+
+    override func setUp() { UserDefaults.standard.removeObject(forKey: "dictionaryEntries") }
+    override func tearDown() { UserDefaults.standard.removeObject(forKey: "dictionaryEntries") }
+
+    /// Spelling rules run BEFORE expansion, so a rule can never rewrite the
+    /// inside of freshly-inserted user text. Reversed, the "gmail"→"GMail" rule
+    /// below would corrupt the address the user just expanded — their own email,
+    /// silently edited into something they never wrote.
+    func testSpellingRulesNeverRewriteInsideAnExpansion() {
+        _ = store.add(term: "GMail", misspelling: "gmail")
+        _ = store.add(term: "my email", expansion: "dev@gmail.com")
+
+        let out = GeminiTranscriptionService.applyDictionary(to: "reach me at my email", store)
+        XCTAssertEqual(out, "reach me at dev@gmail.com",
+                       "the expansion is user data and must survive the spelling pass untouched")
+    }
+
+    /// Both halves still work when they don't collide.
+    func testSpellingAndExpansionBothApply() {
+        _ = store.add(term: "Kubernetes", misspelling: "cooper netties")
+        _ = store.add(term: "my number", expansion: "(720) 555-0134")
+
+        let out = GeminiTranscriptionService.applyDictionary(to: "cooper netties — call my number", store)
+        XCTAssertEqual(out, "Kubernetes — call (720) 555-0134")
+    }
+}
+
+final class DictionarySnippetStoreTests: XCTestCase {
+    private let store = DictionaryStore()
+
+    override func setUp() { UserDefaults.standard.removeObject(forKey: "dictionaryEntries") }
+    override func tearDown() { UserDefaults.standard.removeObject(forKey: "dictionaryEntries") }
+
+    /// The privacy line that matters: a dictionary full of addresses and phone
+    /// numbers must add nothing to what the request carries. Triggers ride along
+    /// (that is what makes the recogniser hear them); expansions never do.
+    func testExpansionsNeverReachTheVocabulary() {
+        _ = store.add(term: "my email address", expansion: "dev@example.com")
+        let vocabulary = store.sanitizedVocabulary()
+        XCTAssertTrue(vocabulary.contains("my email address"), "the spoken trigger is a term like any other")
+        XCTAssertFalse(vocabulary.contains { $0.contains("dev@example.com") },
+                       "an expansion must never leave the machine")
+    }
+
+    func testSnippetsSurviveACSVRoundTrip() {
+        _ = store.add(term: "my signoff", expansion: "Thanks,\nSudarshan — \"the\" one, x")
+        let csv = store.exportCSV()
+
+        UserDefaults.standard.removeObject(forKey: "dictionaryEntries")
+        XCTAssertEqual(store.importCSV(csv), 1)
+
+        let restored = store.entries().first
+        XCTAssertEqual(restored?.term, "my signoff")
+        XCTAssertEqual(restored?.expansion, "Thanks,\nSudarshan — \"the\" one, x",
+                       "commas, quotes and newlines are all legal inside an expansion")
+    }
+
+    /// A headerless file whose first term happens to start with "term" must not
+    /// lose its first row — the existing guard, re-checked with three columns.
+    func testThreeColumnHeaderIsDroppedButDataIsNot() {
+        XCTAssertEqual(store.importCSV("term,misspelling,expansion\n\"terminal\",\"\",\"\""), 1)
+        XCTAssertEqual(store.entries().first?.term, "terminal")
+    }
+
+    func testOverlongExpansionIsRefused() {
+        let huge = String(repeating: "x", count: DictionaryEntry.maxExpansionLength + 1)
+        XCTAssertFalse(store.add(term: "my essay", expansion: huge))
+        XCTAssertTrue(store.entries().isEmpty)
+    }
+
+    /// An entry with no expansion is still a plain term, and must not turn up as
+    /// a snippet with an empty replacement (which would delete the trigger).
+    func testPlainTermsAreNotSnippets() {
+        _ = store.add(term: "Kubernetes", misspelling: "cooper netties")
+        XCTAssertTrue(store.snippets().isEmpty)
+    }
+}
+
+/// The stored shape. `expansion` was added to a struct that is already on disk
+/// in every existing install, so the old form has to keep decoding — a throw
+/// here empties somebody's dictionary on upgrade.
+final class DictionaryEntryWireFormatTests: XCTestCase {
+    private func decode(_ json: String) throws -> [DictionaryEntry] {
+        try JSONDecoder().decode([DictionaryEntry].self, from: Data(json.utf8))
+    }
+
+    func testDecodesEntriesWrittenBeforeExpansionExisted() throws {
+        let legacy = """
+        [{"id":"1B4E28BA-2FA1-11D2-883F-B9A761BDE3FB","term":"Kubernetes",\
+        "misspelling":"cooper netties","starred":false,"createdAt":800000000.0}]
+        """
+        let entries = try decode(legacy)
+        XCTAssertEqual(entries.first?.term, "Kubernetes")
+        XCTAssertNil(entries.first?.expansion)
+        XCTAssertFalse(entries.first?.isSnippet ?? true)
+    }
+
+    func testDecodesASnippetEntry() throws {
+        let stored = """
+        [{"id":"1B4E28BA-2FA1-11D2-883F-B9A761BDE3FB","term":"my email address",\
+        "expansion":"dev@example.com","starred":true,"createdAt":800000000.0}]
+        """
+        let entry = try XCTUnwrap(decode(stored).first)
+        XCTAssertEqual(entry.expansion, "dev@example.com")
+        XCTAssertTrue(entry.isSnippet)
+        XCTAssertNil(entry.misspelling)
+    }
+
+    /// Round-tripping through the encoder must produce something the decoder
+    /// accepts — the guard against a future field being added non-optionally.
+    func testRoundTripsThroughItsOwnEncoder() throws {
+        let original = DictionaryEntry(term: "my number", expansion: "(720) 555-0134")
+        let data = try JSONEncoder().encode([original])
+        let restored = try JSONDecoder().decode([DictionaryEntry].self, from: data)
+        XCTAssertEqual(restored.first, original)
+    }
+}


### PR DESCRIPTION
## What

A dictionary entry may now carry an **expansion**, turning its term into a spoken shortcut — say *"my email address"*, get the address. The Dictionary window gains an optional `Expands to…` field; CSV gains a third column.

This is the one piece of the dictionary that people migrating from other dictation apps notice missing. Spelling rules fix words the model misheard; a snippet substitutes something you never said in full.

## Two behaviours that separate it from a spelling rule

**Expansions are inserted verbatim.** `apply` propagates case on purpose — `"Standup"` → `"Stand-up"` should follow the sentence. An expansion must not, or a trigger opening a sentence Title-Cases an address. There's a test for exactly this.

**Expansion is one pass over the original text.** `apply` rewrites `result` once per rule, which is harmless for short corrections but not for snippets: an expansion is arbitrary user text, so a later rule could match *inside* freshly-inserted content and corrupt it. Matching the original and copying the gaps makes that structurally impossible, and also means a trigger appearing inside another expansion stays literal — no cascade, no recursive pair that fails to terminate.

## Order matters, and is now enforced in one place

Spelling rules first, then expansion. Reversed, a `"gmail"` → `"GMail"` rule rewrites the inside of the address the user just expanded — their own data, silently edited into something they never wrote. (The lookarounds match across punctuation, so `@gmail.com` really would be hit.)

The four call sites that applied dictionary rules now share `applyDictionary`, the same cannot-drift-apart treatment `sanitizedVocabulary` already gets.

## Expansions never leave the machine

Triggers ride in the vocabulary — that's what makes the recogniser hear them cleanly, which is what makes expansion fire. The expansion itself is substituted locally after the response, so a dictionary full of addresses and phone numbers adds nothing to what the request carries. Tested.

## Compatibility

`expansion` is optional because the struct is already on disk in every install — a decode throw on the old shape would empty somebody's dictionary on upgrade. The legacy form, the snippet form and an encoder round trip are all fixtures.

## Testing

`swift test --package-path JotCore` green. 22 new tests covering verbatim casing, non-reentrancy, longest-trigger-wins, word boundaries, trailing punctuation, multi-line expansions, pass ordering, the CSV round trip with commas/quotes/newlines, the vocabulary exclusion, and wire-format compatibility.

Also dogfooded: built locally, imported a real 21-entry dictionary, and confirmed by dictation that a trigger opening a sentence expands without Title-Casing.

No prompt changes, so the `PromptV1` evidence requirement in CONTRIBUTING doesn't apply here.

https://claude.ai/code/session_01QUqGUeLiRyc1DVfkyV4oGr